### PR TITLE
fix: events no longer grows-while-looping anymore

### DIFF
--- a/lua/profile.lua
+++ b/lua/profile.lua
@@ -116,6 +116,8 @@ end
 ---Write the trace to a file
 ---@param filename string
 M.export = function(filename)
+  local original_recording = instrument.recording
+  instrument.recording = false
   local file = assert(io.open(filename, "w"))
   local events = instrument.get_events()
   file:write("[")
@@ -138,6 +140,7 @@ M.export = function(filename)
   end
   file:write("]")
   file:close()
+  instrument.recording = original_recording
 end
 
 return M


### PR DESCRIPTION
Closes https://github.com/stevearc/profile.nvim/issues/6

The issue was that `events` was growing in-size while the for loop was running. By making a shallow copy here, the loop completes as expected.