### PR TITLE
Added get_process_id / get_thread_id

### DIFF
--- a/lua/profile.lua
+++ b/lua/profile.lua
@@ -5,8 +5,8 @@ local util = require("profile.util")
 local M = {}
 
 local event_defaults = {
-  pid = 1,
-  tid = 1,
+  pid = util.DEFAULT_PROCESS_ID,
+  tid = util.DEFAULT_THREAD_ID,
 }
 
 ---Call this at the top of your init.vim to get durations for autocmds. If you
@@ -71,6 +71,8 @@ M.log_start = function(name, ...)
     args = util.format_args(...),
     cat = "function,manual",
     ph = "B",
+    pid = util.get_process_id(),
+    tid = util.get_thread_id(),
     ts = clock(),
   })
 end
@@ -86,6 +88,8 @@ M.log_end = function(name, ...)
     name = name,
     args = util.format_args(...),
     cat = "function,manual",
+    pid = util.get_process_id(),
+    tid = util.get_thread_id(),
     ph = "E",
     ts = clock(),
   })
@@ -103,6 +107,8 @@ M.log_instant = function(name, ...)
     args = util.format_args(...),
     cat = "",
     ph = "i",
+    pid = util.get_process_id(),
+    tid = util.get_thread_id(),
     ts = clock(),
     s = "g",
   })

--- a/lua/profile/instrument.lua
+++ b/lua/profile/instrument.lua
@@ -66,6 +66,8 @@ local function wrap_function(name, fn)
       local delta = clock() - start
       M.add_event({
         name = name,
+        pid = util.get_process_id(),
+        tid = util.get_thread_id(),
         args = arg_string,
         cat = "function",
         ph = "X",

--- a/lua/profile/util.lua
+++ b/lua/profile/util.lua
@@ -5,6 +5,46 @@ local tbl_isarray = vim.isarray or vim.tbl_isarray or vim.tbl_islist
 local pack_len = vim.F.pack_len
 local split = vim.split
 
+
+M.DEFAULT_PROCESS_ID = 1
+M.DEFAULT_THREAD_ID = 1
+
+if jit and jit.version then
+  local ffi = require("ffi")
+
+  if vim.fn.has("win32") == 1 or vim.fn.has("win64") == 1 then
+    ffi.cdef([[
+      typedef unsigned long DWORD;
+      DWORD GetCurrentThreadId();
+    ]])
+
+    ---@return number # The current thread's ID number (1-or-more value).
+    function M.get_thread_id()
+      return ffi.C.GetCurrentThreadId()
+    end
+  else
+    ffi.cdef([[
+      typedef int pid_t;
+      pid_t gettid();
+    ]])
+
+    ---@return number # The current thread's ID number (1-or-more value).
+    function M.get_thread_id()
+      return ffi.C.gettid()
+    end
+  end
+else
+  ---@return number # The current thread's ID number (1-or-more value).
+  function M.get_thread_id()
+    return M.DEFAULT_THREAD_ID
+  end
+end
+
+---@return number # The current process's ID number (1-or-more value).
+function M.get_process_id()
+  return vim.uv.os_getpid()
+end
+
 ---@param glob string
 ---@return string
 M.path_glob_to_regex = function(glob)


### PR DESCRIPTION
I noticed that the `pid` and `tid` values that this plugin writes out seem to just be placeholders. I've added implementations for the events that have been working for me and wanted to contribute them back.

It's worth noting that `get_thread_id` relies on FFI, which is a Luajit only feature. If Neovim runs from non-luajit then we return the old placeholder thread ID, `1`. That said I think just about everyone using Neovim uses the default lua version which is luajit. So this case should be pretty rare.