### PR TITLE
Added events as an optional export parameter

### DIFF
--- a/lua/profile.lua
+++ b/lua/profile.lua
@@ -124,17 +124,14 @@ M.print_instrumented_modules = function()
 end
 
 ---Write the trace to a file
----@param filename string
----    A path on-disk where the profiler flamegraph will be exported to.
+---@param filename string A path on-disk where the profiler flamegraph will be exported to.
 M.export = function(filename)
   M.write_events_to_file(filename, instrument.get_events())
 end
 
 ---Write the trace to a file
----@param filename string
----    A path on-disk where the profiler flamegraph will be exported to.
----@param events profile.Event[]
----    The recorded profile event to export. If none are given, the global events are exported instead.
+---@param filename string A path on-disk where the profiler flamegraph will be exported to.
+---@param events profile.Event[] The recorded profile event to export. If none are given, the global events are exported instead.
 ---@private
 M.write_events_to_file = function(filename, events)
   local original_recording = instrument.recording


### PR DESCRIPTION
This PR modifies the export process.

Before: Export the global `instrument.get_events()`
After: If the user has provided an explicit list of events, export those. Otherwise, export the global `instrument.get_events()`

Sometimes I want to export a subset of the overall events. So I make a copy using `vim.fn.copy(instrument.get_events())`, get a slice of those events, and now just need a way to export that slice. This PR makes that possible.